### PR TITLE
fix: support namespace for lumen 8.x

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Avlyalin\SberbankAcquiring\Providers;
 
-use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
Lumen не поддерживает namespace Illuminate\Foundation\Support\Providers\EventServiceProvider.
нашел в просторах интернета такое решение, и это на lumen работает. Для laravel вроде тоже должно работать.